### PR TITLE
Move publicPath to output entry, copy over .eslintrc.json.

### DIFF
--- a/febs-init.js
+++ b/febs-init.js
@@ -1,13 +1,14 @@
 const path = require('path');
 const fs = require('fs-extra');
+
 const projectPath = process.cwd();
-const febsPath = path.resolve(__dirname);
-const templatesPath = path.resolve(febsPath, 'templates/');
+const templatesPath = path.resolve(__dirname, 'templates/');
 
 function febsInit() {
   fs.ensureDirSync(path.resolve(projectPath, 'src/'));
-  fs.copySync(path.resolve(templatesPath, 'entry.js'), path.resolve(projectPath, 'src/entry.js'))
-  fs.copySync(path.resolve(templatesPath, 'entry.less'), path.resolve(projectPath, 'src/entry.less'))
+  fs.copySync(path.resolve(templatesPath, 'entry.js'), path.resolve(projectPath, 'src/entry.js'));
+  fs.copySync(path.resolve(templatesPath, 'entry.less'), path.resolve(projectPath, 'src/entry.less'));
+  fs.copySync(path.resolve(__dirname, '.eslintrc.json'), path.resolve(projectPath, '.eslintrc.json'));
 }
 
 module.exports = febsInit;

--- a/package-lock.json
+++ b/package-lock.json
@@ -277,6 +277,15 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
+    "asset-tag-frag-webpack-plugin": {
+      "version": "git+https://github.com/rei/asset-tag-frag-webpack-plugin.git#efe7ff24583d644f2581df97557198a8fcfc65fb",
+      "requires": {
+        "istanbul": "0.4.5",
+        "memory-fs": "0.4.1",
+        "mocha": "3.5.0",
+        "ramda": "0.24.1"
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",

--- a/webpack-config/webpack.base.conf.js
+++ b/webpack-config/webpack.base.conf.js
@@ -14,12 +14,12 @@ module.exports = {
 
   entry: {
     app: path.resolve(projectPath, 'src/entry.js'),
-    publicPath: '/dist/',
   },
 
   output: {
     path: path.resolve(projectPath, 'dist', packageName),
     filename: '[name].bundle.js',
+    publicPath: '/dist/',
   },
 
   resolve: {

--- a/webpack.overrides.conf.js
+++ b/webpack.overrides.conf.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const projectPath = process.cwd();
 
-const packageName = require(path.join(projectPath, '/package.json')).name
+const packageName = require(path.join(projectPath, '/package.json')).name;
 
 module.exports = {
 


### PR DESCRIPTION
* Move publicPath entry to output. This was causing following error:
```
ERROR in Entry module not found: Error: Can't resolve 'dist' in '/Users/aperkin/code/febs-client2'
```
* Copy the .eslintrc.json file into client. This was causing:
```
ERROR in ./src/entry.js
Module build failed: Error: No ESLint configuration found.
```
* Minor formatting updates.