### PR TITLE
Add watch functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 coverage/
 .babelcache/
-dest/
+.idea/
+*.iml

--- a/bin/febs
+++ b/bin/febs
@@ -27,7 +27,6 @@ program
   .command('prod')
   .description('Builds front-end assets optimized for production\n')
   .action((command) => {
-    const verbose = command.parent.verbose;
     febs({
       command,
       logLevel: command.parent.verbose ? 'verbose' : 'info',
@@ -37,10 +36,9 @@ program
 program
   .command('dev')
   .description('Builds/Serves front-end assets optimized for local development\n')
-  .option('--no-dev-server')
+  .option('--no-dev-server', 'Run dev build with no development server.')
+  .option('--watch', 'Run dev build in watch mode.')
   .action((command) => {
-    const verbose = command.parent.verbose;
-
     if (command.devServer) {
       febs({
         command,
@@ -70,8 +68,7 @@ program
 program
   .command('init')
   .description('Creates basic scaffolding for a new front-end build\n')
-  .action((command) => {
-    const verbose = command.parent.verbose;
+  .action(() => {
     febsInit();
   });
 
@@ -80,6 +77,7 @@ program
   .on('--help', () => {
     process.stdout.write(`  Examples:
         $ febs dev --no-dev-server
+        $ febs dev --watch
         $ febs build --verbose
         $ febs test
         $ febs test --coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "febs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,11 +2502,6 @@
         "eslint-restricted-globals": "0.1.1"
       }
     },
-    "eslint-config-riot": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
-      "integrity": "sha1-+9ZThpgLMPvNDhMF1MP7hhTvIRk="
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
@@ -7250,46 +7245,52 @@
       }
     },
     "riot": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/riot/-/riot-3.6.1.tgz",
-      "integrity": "sha1-uALrlcpbohkZ5Hk2d+MYoRwoXTY=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/riot/-/riot-2.4.1.tgz",
+      "integrity": "sha1-SS88ixzG+Jko4mMWjoVSB7CxYkc=",
       "requires": {
-        "riot-cli": "3.0.2",
-        "riot-compiler": "3.2.4",
-        "riot-observable": "3.0.0",
-        "riot-tmpl": "3.0.8",
-        "simple-dom": "0.3.2",
-        "simple-html-tokenizer": "0.4.1"
+        "riot-cli": "2.6.2",
+        "riot-compiler": "2.5.7",
+        "riot-observable": "2.5.0",
+        "riot-route": "2.5.0",
+        "riot-tmpl": "2.4.2",
+        "simple-dom": "0.3.0",
+        "simple-html-tokenizer": "0.2.6"
       },
       "dependencies": {
         "riot-cli": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/riot-cli/-/riot-cli-3.0.2.tgz",
-          "integrity": "sha1-nzwemFF9FeXDb8kH5ngCgqtHoqI=",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/riot-cli/-/riot-cli-2.6.2.tgz",
+          "integrity": "sha1-Lv1DvtiyhtVY3Am1Wl8OgMnxDAk=",
           "requires": {
             "chalk": "1.1.3",
             "chokidar": "1.7.0",
             "co": "4.6.0",
             "optionator": "0.8.2",
-            "riot-compiler": "3.2.4",
-            "rollup": "0.41.6",
+            "riot-compiler": "2.5.7",
+            "rollup": "0.36.4",
             "shelljs": "0.7.8"
           }
         }
       }
     },
     "riot-compiler": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/riot-compiler/-/riot-compiler-3.2.4.tgz",
-      "integrity": "sha1-4LiLzx3+kY0fWqrqgm9Wjy70lCE=",
-      "requires": {
-        "skip-regex": "0.2.0"
-      }
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/riot-compiler/-/riot-compiler-2.5.7.tgz",
+      "integrity": "sha1-3EGDZvEXjTnGwY/Z/AGQy+7MFpU="
     },
     "riot-observable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/riot-observable/-/riot-observable-3.0.0.tgz",
-      "integrity": "sha1-i70tr3KiFBuwQwgt9AI9xQS60us="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/riot-observable/-/riot-observable-2.5.0.tgz",
+      "integrity": "sha1-X7loJoW269UtVK0PTE5yr565BMQ="
+    },
+    "riot-route": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/riot-route/-/riot-route-2.5.0.tgz",
+      "integrity": "sha1-qvzQ7i30cNuJpYd3DNVXdgsqwrU=",
+      "requires": {
+        "riot-observable": "2.5.0"
+      }
     },
     "riot-tag-loader": {
       "version": "1.0.0",
@@ -7313,12 +7314,9 @@
       }
     },
     "riot-tmpl": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/riot-tmpl/-/riot-tmpl-3.0.8.tgz",
-      "integrity": "sha1-3WVOcqOhUgywCcvvcMc4Vt7VhKY=",
-      "requires": {
-        "eslint-config-riot": "1.0.0"
-      }
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/riot-tmpl/-/riot-tmpl-2.4.2.tgz",
+      "integrity": "sha1-2qGobEMNv17XlTABQ1XxBpKtZ7c="
     },
     "ripemd160": {
       "version": "2.0.1",
@@ -7330,9 +7328,9 @@
       }
     },
     "rollup": {
-      "version": "0.41.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
-      "integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
+      "version": "0.36.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.36.4.tgz",
+      "integrity": "sha1-oiRJTFOGwdc9OPe7hvafXrARo9I=",
       "requires": {
         "source-map-support": "0.4.15"
       }
@@ -7741,19 +7739,14 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-dom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/simple-dom/-/simple-dom-0.3.2.tgz",
-      "integrity": "sha1-BmPRDxVW8VAFUdUY9W46ughxNx0="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/simple-dom/-/simple-dom-0.3.0.tgz",
+      "integrity": "sha1-bskbIB4zYQAwTMyimUH9zDT49pI="
     },
     "simple-html-tokenizer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
-      "integrity": "sha1-AomIu3/osuZkVnbYIFJYfUQLAtM="
-    },
-    "skip-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/skip-regex/-/skip-regex-0.2.0.tgz",
-      "integrity": "sha1-4lbLoeuYt4pGV0+UYa6TGmkbrG4="
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.2.6.tgz",
+      "integrity": "sha1-pu+re8cFzzqW8arqoadjZfDRbDM="
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "postcss-loader": "^2.0.6",
     "ramda": "^0.25.0",
     "request": "^2.81.0",
-    "riot": "^3.6.1",
+    "riot": "~2.4.1",
     "riot-tag-loader": "^1.0.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "febs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This PR will add `watch` mode to `febs`.  Client would run via, for example:

     $ febs dev --watch --no-dev-server

This runs build and puts client in watch mode and will rebuild on code update. (see https://webpack.js.org/api/node/#watching).

Also pulling back `Riot` version to be consistent with what we use at REI.