### PR TITLE
Removing test api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@
 
 ## Features
 - Command-line interface (see [Usage](#usage))
-- Supports building:
-  - Vue
-  - Riot
-  - Less
-- Creates development and versioned production builds with sourcemaps.
+- Supports for:
+  - JavaScript/ECMAScript
+    - ECMAScript support via `babel-preset-env` and `browserslist`
+    - Vue.js
+    - Riot.js
+  - Style
+    - LESS
+    - SASS/SCSS
+
+- Creates development and versioned production builds with source maps.
 - Live reloading and code-watching for fast prototyping and development.
-- Runs JavaScript quality checks:
-  - eslint (Airbnb style)
-  - unit tests
-  - code coverage
+- Runs JavaScript lint checks via `eslint` and Airbnb's shared `eslint` config.
 
 ## Installation
 - `npm install --save-dev git+https://github.com/rei/febs.git`
@@ -36,7 +38,7 @@ By default febs is configured for:
 
 #### Start a new febs project
 Requires a package.json file in the same dir where you run the command
-    
+
     $ febs init
 
 #### Production Build
@@ -75,7 +77,7 @@ module.exports = {
   .
   .
   plugins: [
-    new CoolPlugin() 
+    new CoolPlugin()
   ]
 };
 ```
@@ -85,11 +87,6 @@ module.exports = {
 [ ] rename package from febs to rei-febs or scope package to @rei/febs
 
 [ ] Vendor code splitting.
-
-[ ] Unit tests of client code.
-    [x] Node
-    [ ] Riot
-    [ ] Vue
 
 [ ] Code coverage of client code:
     [x] Node

--- a/bin/febs
+++ b/bin/febs
@@ -53,19 +53,6 @@ program
   });
 
 program
-  .command('test')
-  .description('Runs unit tests.\n')
-  .option('-c, --cover', 'Run test coverage')
-  .action((command) => {
-    const verbose = command.parent.verbose;
-
-    febs({
-      command,
-      logLevel: verbose ? 'verbose' : 'info',
-    }).test();
-  });
-
-program
   .command('init')
   .description('Creates basic scaffolding for a new front-end build\n')
   .action(() => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const wp = require('webpack');
 const logger = require('./lib/logger');
 const merge = require('webpack-merge');
 const path = require('path');
-const { spawn } = require('child_process');
 const devServer = require('./lib/dev-server');
 const webpackConfigBase = require('./webpack-config/webpack.base.conf');
 const R = require('ramda');
@@ -155,31 +154,6 @@ module.exports = function init(conf = {}) {
     cleanDir
   );
 
-  const test = function test() {
-    let cmd = spawn(`${__dirname}/node_modules/mocha/bin/mocha`, ['--colors', `${command.watch ? '--watch' : 'test'}`]);
-
-    if (command.cover) {
-      cmd = spawn(`${__dirname}/node_modules/istanbul/lib/cli.js`, ['cover', `${__dirname}/node_modules/mocha/bin/_mocha`, '--', '--colors', 'test']);
-    }
-
-    cmd.stdout.on('data', (data) => {
-      const d = data.toString();
-      if (d.length > 1) {
-        console.log(d);
-      }
-    });
-
-    // It seems istanbul report output goes to stderr.
-    cmd.stderr.on('data', (data) => {
-      if (command.cover) {
-        logger.info(data.toString());
-        return;
-      }
-
-      logger.error(data.toString());
-    });
-  };
-
   /**
    * Start the webpack dev server.
    */
@@ -203,7 +177,6 @@ module.exports = function init(conf = {}) {
   }
 
   return {
-    test,
     compile,
     createCompiler,
     webpackCompileDone,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "febs",
-  "version": "0.11.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "febs",
-  "version": "0.11.0",
+  "version": "2.0.0",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Removing the test api that runs unit tests on client code. The reasons
for this are:
- FEBS should really be responsible for building the code, not testing
  the code. Testing should be handled prior to building, e.g. via npm
  test script.
- Handling of the testing programmatically is cumbersome (e.g. error
  detection, spawning, etc.) and requires a lot of code to maintain.
- Test frameworks focus on the CLI not on the programmatic API, often
  providing little to no documentation for the programmatic API.
- All unit test framework functionality is available via the CLI, no
  code needed.
- Code coverage is handled automatically via command line in both mocha and jest.