### PR TITLE
Fixing invalid html and breaking template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,8 +33,7 @@
 
   <p>
     Your development bundles are written to
-  <pre>/dist/&lt;package name&gt;/app.bundle.[js|css]</pre>
-  </package>
+  <pre>/dist/&lt;package name&gt;/app.bundle.[js|css]&lt;/package&gt;</pre>
 
   <h3>Production bundles</h3>
   <p>


### PR DESCRIPTION
the package closing tag was not escaped and causes a template error.