### PR TITLE
Adding Vue as a peer-dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "2.5.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11335,9 +11335,10 @@
       }
     },
     "vue": {
-      "version": "2.5.15",
-      "resolved": "http://mvnrepos.rei.com/content/groups/npm-all/vue/-/vue-2.5.15.tgz",
-      "integrity": "sha512-uUcDI147VCQYA/9AqoEECddWdTQgrhnwAd6KDsl0pF1hiLpxqaYqIgArhnegU+QZ18DQrKvZNcR3x2QM1iaroQ=="
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
+      "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ==",
+      "dev": true
     },
     "vue-eslint-parser": {
       "version": "2.0.3",
@@ -11467,9 +11468,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.5.15",
-      "resolved": "http://mvnrepos.rei.com/content/groups/npm-all/vue-template-compiler/-/vue-template-compiler-2.5.15.tgz",
-      "integrity": "sha512-v3GRVovW8fWO01SAJ+1MbdzbCN+hVBusoqUOBE5FR9dVMGo3p/WDO2gRS/+gEgAALtL7i5pxi+V2l6EauM3XDA==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
+      "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
       "requires": {
         "de-indent": "1.0.2",
         "he": "1.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {
@@ -67,9 +67,8 @@
     "sass-loader": "^6.0.7",
     "style-loader": "^0.18.2",
     "uglifyjs-webpack-plugin": "^1.2.3",
-    "vue": "^2.5.15",
     "vue-loader": "^13.7.1",
-    "vue-template-compiler": "^2.5.15",
+    "vue-template-compiler": "^2.5.17",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.6.1",
     "webpack-manifest-plugin": "^1.3.2",
@@ -78,7 +77,11 @@
   },
   "devDependencies": {
     "riot-compiler": "^3.4.0",
-    "sinon": "^6.1.4"
+    "sinon": "^6.1.4",
+    "vue": "^2.5.17"
+  },
+  "peerDependencies": {
+    "vue": "^2.5.17"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Vue is required in the parent application and we want to ensure we are at the version specified in febs.

If the client app does not pull in `vue` as a dependency, they'll see this on the install:
```
npm WARN @rei/febs@2.6.1 requires a peer of vue@^2.5.17 but none is installed. You must install peer dependencies yourself.
```
and will, of course, get a `can't find module` error when building.