### PR TITLE
Babel and eslint to ignore node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "2.5.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {

--- a/webpack-config/webpack.base.conf.js
+++ b/webpack-config/webpack.base.conf.js
@@ -77,6 +77,7 @@ module.exports = {
     rules: [
       {
         test: /\.(js|tag)$/,
+        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: {
@@ -88,6 +89,7 @@ module.exports = {
         enforce: 'pre',
         test: /\.(js|vue)$/,
         include: path.resolve('.'),
+        exclude: /node_modules/,
         use: {
           loader: 'eslint-loader',
           options: {


### PR DESCRIPTION
- Configuring the babel and eslint to ignore node_modules by default.