### PR TITLE
Replacing exclude with include for js

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,9 +4,7 @@
 
 ## Summary
 
-`FEBS` is an extensible [webpack](https://webpack.js.org/)\-based [front-end build system]
-(https://engineering.rei
-.com/frontend/the-rei-front-end-build-system.html) 
+`FEBS` is an extensible [webpack](https://webpack.js.org/)\-based [front-end build system](https://engineering.rei.com/frontend/the-rei-front-end-build-system.html) 
 designed to be used by a community of front-end developers or a series of projects using a similar set of technologies in order to reduce duplicate effort on build configuration.
 
 Its code falls into two categories
@@ -26,7 +24,7 @@ Its code falls into two categories
 - Produces a [Build Manifest](#build-manifest) so you can insert assets on your page using an [Asset Injector](#asset-injector)
 
 Learn more about [REI's Front-End Build System ](https://engineering.rei.com/frontend/the-rei-front-end-build-system.html)
-by checking out the introductory post on the [REI Co-op Engineering blog](https://engineering.rei.com)
+by checking out the introductory post on the [REI Co-op Engineering blog](https://engineering.rei.com).
 
 ## Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {

--- a/webpack-config/webpack.base.conf.js
+++ b/webpack-config/webpack.base.conf.js
@@ -78,7 +78,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /node_modules/,
+        include: () => (process.env.febs_test ? path.join(projectPath, 'test', 'fixtures') : [path.join(projectPath, 'src'), /node_modules\/@rei/]),
         use: {
           loader: 'babel-loader',
           options: {


### PR DESCRIPTION
- Removing exclusion of entire `/node_modules` directory as some modules coming in from the `@rei` namespace currently do not have their own builds and require a "parent" build.