### PR TITLE
Remove webpack-manifest-plugin during SSR build

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ module.exports = function init(command, conf = {}) {
     startDevServerFn,
     getWebpackConfig,
     addVueSSRToWebpackConfig,
-    getWebpackConfigCurried: getWebpackConfigFn,
+    getWebpackConfigFn,
     febsConfigMerge,
   };
 };

--- a/index.js
+++ b/index.js
@@ -3,10 +3,11 @@
 const wp = require('webpack');
 const R = require('ramda');
 const path = require('path');
+const merge = require('webpack-merge');
 const logger = require('./lib/logger');
 const lib = require('./lib');
-const merge = require('webpack-merge');
 const devServer = require('./lib/dev-server');
+const fsExtra = require('fs-extra');
 
 const projectPath = process.cwd();
 
@@ -21,8 +22,6 @@ const projectPath = process.cwd();
  * @param conf.fs The file system (passed in from unit tests.)
  */
 module.exports = function init(command, conf = {}) {
-  let ssr = false;
-
   const febsConfigArg = conf;
 
   // Allow for in-memory fs for testing.
@@ -65,6 +64,8 @@ module.exports = function init(command, conf = {}) {
     return R.merge(febsConfig, febsConfigFileJSON);
   };
 
+  const isSSR = () => getFebsConfig().ssr;
+
   const getPackageName = () => {
     const projectPackageJson = path.join(projectPath, 'package.json');
     return require(projectPackageJson).name;
@@ -77,10 +78,8 @@ module.exports = function init(command, conf = {}) {
 
     // working to style guide this
     if (febsConfig.entry) {
-      for (let key in febsConfig.entry) {
-        febsConfig.entry[key] = febsConfig.entry[key].map(function(entryFile) {
-          return path.resolve(projectPath, entryFile);
-        });
+      for (const key in febsConfig.entry) {
+        febsConfig.entry[key] = febsConfig.entry[key].map(entryFile => path.resolve(projectPath, entryFile));
       }
       wpConf.entry = febsConfig.entry;
     }
@@ -88,28 +87,58 @@ module.exports = function init(command, conf = {}) {
     return wpConf;
   };
 
-  const getWebpackConfig = (confOverride) => {
-    const webpackConfigBase = require('./webpack-config/webpack.base.conf');
+  /**
+   * Modifications needed for SSR.
+   *
+   * @param ssr
+   * @param wpConf
+   * @returns {*}
+   */
+  const addVueSSRToWebpackConfig = R.curry((ssr, wpConf) => {
+    if (!ssr) {
+      return wpConf;
+    }
+
+    // Remove Manifest plugin during SSR build.
+    const plugins = wpConf.plugins
+      .filter(plugin => plugin.constructor.name !== 'ManifestPlugin');
+
+    const wpConfNoManifest = R.merge(R.dissoc('plugins', wpConf), {
+      plugins,
+    });
+
+    // Add SSR config.
     const webpackServerConf = require('./webpack-config/webpack.server.conf');
+    return merge.smartStrategy({
+      entry: 'replace',
+      plugins: 'append',
+    })(wpConfNoManifest, webpackServerConf);
+  });
+
+  /**
+   * Get the webpack config using:
+   *  - webpack.base.conf.js
+   *  - confOverrides
+   *  - febs-config.json
+   *
+   * @param confOverride Optional conf overrides that comes in either from
+   * webpack.overrides.conf or from unit tests.
+   */
+  const getWebpackConfigBase = (confOverride) => {
+    const webpackConfigBase = require('./webpack-config/webpack.base.conf');
     const configsToMerge = [webpackConfigBase];
 
-    let wpMergeConf = {
+    // Config for webpack-merge
+    const wpMergeConf = {
       entry: 'replace',
     };
 
     // Overrides config.
     configsToMerge.push(getOverridesConf(confOverride));
 
-    if (ssr) {
-      configsToMerge.push(webpackServerConf);
-      wpMergeConf = R.merge(wpMergeConf, {
-        plugins: 'append',
-      });
-    }
-
     const wpConf = merge.smartStrategy(wpMergeConf)(configsToMerge);
 
-    // Force output path to always be the same
+    // Force output path to always be the same. (Overrideable in febs-config)
     wpConf.output.path = webpackConfigBase.output.path;
 
     // Ensure febs config makes the final configurable decisions
@@ -117,17 +146,41 @@ module.exports = function init(command, conf = {}) {
   };
 
   /**
- * Create's compiler instance with appropriate environmental
- * webpack.conf merged with the webpack.overrides.
- *
- * @param {Object} wpConf The final webpack conf object.
- * @return {Object} The webpack compiler.
- */
+   * Get the webpack config. This depends upon:
+   *  - the base webpack config.
+   *  - the webpack server config for optional SSR (ssr property in febs-config)
+   *  - any other overrides coming in from febs-config.json.
+   *  - optional overrides passed in from unit tests.
+   */
+  const getWebpackConfigFn = ssr => R.compose(
+    addVueSSRToWebpackConfig(ssr),
+    getWebpackConfigBase
+  );
+
+  /**
+   * Configure
+   * @param ssr Whether or not to include SSR webpack build config.
+   * @returns {function} A function that takes overrides argument
+   * and returns the final webpack config.
+   */
+  const getWebpackConfig = ssr => getWebpackConfigFn(ssr);
+
+  /**
+   * Create's compiler instance with appropriate environmental
+   * webpack.conf merged with the webpack.overrides/febs-config/SSR configs.
+   *
+   * @param {WebpackOptions} wpConf The final webpack config object.
+   * @return {Object} The webpack compiler instance.
+   */
   const createWebpackCompiler = wpConf => wp(wpConf);
 
-  const createCompiler = R.compose(
+  /**
+   * Create the webpack compiler.
+   * @param {boolean} ssr Whether or not to include Vue SSR build.
+   */
+  const createCompiler = ssr => R.compose(
     createWebpackCompiler,
-    getWebpackConfig
+    getWebpackConfig(ssr)
   );
 
   /**
@@ -174,37 +227,20 @@ module.exports = function init(command, conf = {}) {
   };
 
   /**
-   * Recursive directory clean. Does not delete parent directory.
-   * @param dir The directory to clean.
+   * Clean the build destination directory.
    */
-  const cleanDir = function cleanDir(dir = getWebpackConfig().output.path) {
-    if (!dir || !fs.existsSync(dir)) {
-      return false;
-    }
-
-    const items = fs.readdirSync(dir).map(i => path.resolve(dir, i));
-
-    items.forEach((item) => {
-      if (fs.lstatSync(item).isFile()) {
-        fs.unlinkSync(item);
-      } else {
-        const nextItems = fs.readdirSync(item);
-        if (nextItems.length !== 0) {
-          cleanDir(item);
-        }
-        fs.rmdirSync(item);
-      }
-    });
-    return true;
-  };
+  const cleanDestDir = fsExtra.emptyDirSync.bind(null, getWebpackConfig(false)().output.path);
 
   /**
    * Runs the webpack compile either via 'run' or 'watch'.
-   * @returns {*} The webpack compiler instance.
+   * @param ssr Whether or not to run SSR build.
+   * @returns The webpack compiler instance.
    */
-  const runCompile = () => {
+  const runCompile = (ssr) => {
     const compilerFn = command.watch ? 'watch' : 'run';
-    const compiler = createCompiler();
+
+    const compiler = createCompiler(ssr)();
+
     if (compilerFn === 'run') {
       compiler[compilerFn](webpackCompileDone);
     } else {
@@ -224,15 +260,14 @@ module.exports = function init(command, conf = {}) {
    * @returns {Object} Webpack compiler instance.
    */
   const compile = function compile() {
-    cleanDir();
+    cleanDestDir();
 
     // Create client-side bundle
-    runCompile();
+    runCompile(false);
 
-    // Create vue-ssr-server-bundle.json
-    ssr = getFebsConfig().ssr;
-    if (ssr) {
-      runCompile();
+    // If SSRing, create vue-ssr-server-bundle.json.
+    if (isSSR()) {
+      runCompile(true);
     }
   };
 
@@ -241,8 +276,8 @@ module.exports = function init(command, conf = {}) {
    * @param wds Optionally pass in fake wds (UT only)
    */
   const startDevServerFn = wds => R.compose(
-      devServer.bind(null, wds),
-      createCompiler,
+    devServer.bind(null, wds),
+    createCompiler(false),
   );
 
   return {
@@ -251,8 +286,7 @@ module.exports = function init(command, conf = {}) {
     webpackCompileDone,
     startDevServerFn,
     getWebpackConfig,
-    private: {
-      cleanDir,
-    },
+    addVueSSRToWebpackConfig,
+    getWebpackConfigCurried: getWebpackConfigFn,
   };
 };

--- a/index.js
+++ b/index.js
@@ -91,7 +91,9 @@ module.exports = function init(command, conf = {}) {
       const newEntries = R.zipObj(
         R.keys(entry),
         R.values(entry).map(
-          entryArr => entryArr.map(entryPath => path.resolve(projectPath, entryPath))
+          entryArr => entryArr.map(
+            entryPath => path.resolve(projectPath, entryPath)
+          )
         )
       );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {

--- a/test/index-dev-spec.js
+++ b/test/index-dev-spec.js
@@ -388,7 +388,7 @@ describe('FEBS Development Tests', function () {
         fs,
       });
 
-      const wpConfig = febs.getWebpackConfigCurried(true)(wpDevConf);
+      const wpConfig = febs.getWebpackConfigFn(true)(wpDevConf);
       assert(wpConfig.plugins.every(plugin => plugin.constructor.name !== 'ManifestPlugin'));
     });
 
@@ -397,7 +397,7 @@ describe('FEBS Development Tests', function () {
         fs,
       });
 
-      const wpConfig = febs.getWebpackConfigCurried(false)(wpDevConf);
+      const wpConfig = febs.getWebpackConfigFn(false)(wpDevConf);
       assert(wpConfig.plugins.some(plugin => plugin.constructor.name === 'ManifestPlugin'));
     });
   });

--- a/test/index-prod-spec.js
+++ b/test/index-prod-spec.js
@@ -4,9 +4,12 @@
 // Dependencies.
 const assert = require('assert');
 const lib = require('./lib');
+const logger = require('../lib/logger');
 
 describe('FEBS Production Tests', function () {
   let compile;
+
+  logger.setLogLevel('warn'); // Suppress info messages
 
   beforeEach(function () {
     process.env.FEBS_TEST = true;

--- a/test/lib-spec.js
+++ b/test/lib-spec.js
@@ -3,9 +3,13 @@
 
 const assert = require('assert');
 const lib = require('./lib');
+const logger = require('../lib/logger');
 
 describe('FEBS Lib Tests', function () {
   let compile;
+
+  logger.setLogLevel('warn'); // Suppress info messages
+
   beforeEach(function () {
     process.env.FEBS_TEST = true;
     compile = lib.createCompileFn(lib.createFS());

--- a/test/lib/index.js
+++ b/test/lib/index.js
@@ -32,7 +32,7 @@ module.exports = {
       fs,
     });
 
-    const compiler = febs.createCompiler(conf);
+    const compiler = febs.createCompiler(false)(conf);
 
     // Set up in-memory file system for tests.
     compiler.outputFileSystem = fs;


### PR DESCRIPTION
**Issue**: During the SSR build, the manifest plugin is updating the hashes that were generated during the non-SSR build. This results in discrepancies between the actual file name hashes and what is written to `febs-manifest.json`.

**Solution**: We'll remove the `webpack-manifest-plugin` during the SSR build.

Updates in this PR:

- Removing the manifest plugin from plugins array during SSR build.
- Refactoring of SSR code for better separation of concerns/improved maintainability.
- Replace custom directory clean code with `fs-extra.emptyDir`.
- Add some additional basic console logging.
- Refactor `febsConfigMerge` to not update arguments, fixes eslint rule issues.
- Update unit tests.
- Bumping patch. 4.3.1 -> 4.3.2.