### PR TITLE
add ability to specify devserver options in webpack.overrides

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -19,7 +19,9 @@ const runDevServer = (webpackDevServer, compiler) => {
 
   const port = 8080;
   const projectPath = process.cwd();
-  const server = new WDS(compiler, {
+  const devServerOverrides = compiler.options ? compiler.options.devServer : null;
+
+  const localOpts = {
     port,
     stats: {
       colors: true,
@@ -34,6 +36,13 @@ const runDevServer = (webpackDevServer, compiler) => {
     // in the node api.
     open: true,
     openPage: '',
+  };
+  const merged = {
+    ...localOpts,
+    ...devServerOverrides,
+  };
+  const server = new WDS(compiler, {
+    ...merged,
   });
 
   server.listen(port, '127.0.0.1', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.1",
+  "version": "4.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.1",
+  "version": "4.3.4",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Currently, `devServer` options specified in the `webpack.overrides.conf.js` are ignored by `webpack-dev-server` because we are starting it via the node api per https://webpack.js.org/configuration/dev-server/#devserver:

>If you're using dev-server through the Node.js API, the options in devServer will be ignored. Pass the options as a second parameter instead: new WebpackDevServer(compiler, {...}). 

This pr extracts the options from the compiler instance passed into `runDevServer` and adds it to the options object, overriding the defaults if included.

**Note** there is a failing test present on `master` regarding polyfills that is unrelated to this pr