### PR TITLE
Webpack node externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9788,6 +9788,11 @@
         "lodash": "^4.17.5"
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg=="
+    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-dev-server": "^3.2.1",
     "webpack-manifest-plugin": "^2.0.4",
     "webpack-merge": "^4.1.2",
+    "webpack-node-externals": "^1.7.2",
     "winston": "^2.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {

--- a/webpack-config/webpack.server.conf.js
+++ b/webpack-config/webpack.server.conf.js
@@ -1,4 +1,5 @@
 const VueSSRServerPlugin = require('vue-server-renderer/server-plugin');
+const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
 
@@ -6,6 +7,10 @@ module.exports = {
     libraryTarget: 'commonjs2',
   },
   target: 'node',
+
+  externals: nodeExternals({
+    whitelist: [/@rei/,'vue'],
+  }),
 
   plugins: [
     new VueSSRServerPlugin(),


### PR DESCRIPTION
- Use `webpack-node-externals` to reduce size of the ssr bundle. This currently cuts down the bundle from 3.7M to 3.0M.
- No longer see: `[vue-server-renderer-webpack-plugin] It is recommended to externalize dependencies in the server build for better build performance.` during build.