### PR TITLE
Revert externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9788,11 +9788,6 @@
         "lodash": "^4.17.5"
       }
     },
-    "webpack-node-externals": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
-      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg=="
-    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "webpack-dev-server": "^3.2.1",
     "webpack-manifest-plugin": "^2.0.4",
     "webpack-merge": "^4.1.2",
-    "webpack-node-externals": "^1.7.2",
     "winston": "^2.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {

--- a/webpack-config/webpack.server.conf.js
+++ b/webpack-config/webpack.server.conf.js
@@ -1,5 +1,4 @@
 const VueSSRServerPlugin = require('vue-server-renderer/server-plugin');
-const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
 
@@ -7,10 +6,6 @@ module.exports = {
     libraryTarget: 'commonjs2',
   },
   target: 'node',
-
-  externals: nodeExternals({
-    whitelist: [/@rei/,'vue'],
-  }),
 
   plugins: [
     new VueSSRServerPlugin(),


### PR DESCRIPTION
- Reverting changes in 4.3.3, https://github.com/rei/febs/wiki/Changelog#433.
- This was causing issues of missing core-js modules during SSR even
    though core-js was added to whitelist.
- will need to revisit...