### PR TITLE
Disable the SSR build during dev build

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -133,14 +133,14 @@ Here is an example of `entry`/`output` paths using a typical `Java`/`Maven`-like
       }
       "output": {
         "path": "./target/classes/dist"
-      }
+      },
+      "ssr": true
     }
 
 Notes:
  - the `febs-config.json` overrides the `webpack.overrides.config.js` file. (i.e., if `entry` and `output` are specified in both, the build will use the entries in `febs-config.json`.
  - the `entry/output` paths are resolved relative to npm root.
  - the `output` path is appended with `<package name>`, i.e., `dist/details/`. Use the overrides file if you want to specify a unique path. 
- 
 ####  `entry` property
 
 In the `febs-config.json` example above, we are creating our own entry points instead of using the
@@ -155,6 +155,16 @@ In the `febs-config.json` example above we change the default output path to the
 Notes:
 - The `output` paths are specified relative to npm root directory.
 - the `output` path is appended with `<package name>`, i.e., `dist/<package name>/`. Use the overrides file if you want to specify a unique path. 
+
+#### `ssr` property
+
+This value determines whether or not to build the `vue-ssr-server-bundle.json` required
+for server-side rendering.
+
+Notes:
+- Enabling this will add additional time to the build as it essentially needs to run 2 builds, one
+for the client and one for the server. Additionally, the generated  `vue-ssr-server-bundle.json` is very large.
+- This is automatically disabled during development builds, i.e., `febs dev`.
 
 #### Example configuration output
 Given the above example, FEBS will generate two bundles at the following paths:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -165,6 +165,7 @@ Notes:
 - Enabling this will add additional time to the build as it essentially needs to run 2 builds, one
 for the client and one for the server. Additionally, the generated  `vue-ssr-server-bundle.json` is very large.
 - This is automatically disabled during development builds, i.e., `febs dev`.
+- If, for some reason, you do need this enabled during `dev` build, set `resolve.symlinks` property in `webpack.overrides.conf.js`
 
 #### Example configuration output
 Given the above example, FEBS will generate two bundles at the following paths:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -165,7 +165,6 @@ Notes:
 - Enabling this will add additional time to the build as it essentially needs to run 2 builds, one
 for the client and one for the server. Additionally, the generated  `vue-ssr-server-bundle.json` is very large.
 - This is automatically disabled during development builds, i.e., `febs dev`.
-- If, for some reason, you do need this enabled during `dev` build, set `resolve.symlinks` property in `webpack.overrides.conf.js`
 
 #### Example configuration output
 Given the above example, FEBS will generate two bundles at the following paths:

--- a/index.js
+++ b/index.js
@@ -83,7 +83,15 @@ module.exports = function init(command, conf = {}) {
     return R.mergeRight(febsConfig, febsConfigFileJSON);
   });
 
-  const isSSR = () => getFebsConfig().ssr;
+  /**
+   * Determine if we are building SSR bundle.
+   * Note: In dev mode, we disable SSR as it is expensive (time and size) and
+   * slows down live-reloading.
+   * @param {String} buildEnv ("production" || "development")
+   * @param {Object} febsConfig
+   * @returns {boolean}
+   */
+  const isSSR = (buildEnv, febsConfig) => buildEnv !== 'development' && febsConfig.ssr;
 
   const getPackageName = () => {
     const projectPackageJson = path.join(projectPath, 'package.json');
@@ -313,9 +321,7 @@ module.exports = function init(command, conf = {}) {
    */
   const compile = function compile() {
     cleanDestDir();
-
-    // Create client-side bundle
-    runCompile(isSSR());
+    runCompile(isSSR(env, getFebsConfig()));
   };
 
   /**
@@ -336,5 +342,6 @@ module.exports = function init(command, conf = {}) {
     addVueSSRToWebpackConfig: addVueSSRConfigToConfigList,
     getWebpackConfigFn: getWebpackConfigsFn,
     febsConfigMerge,
+    isSSR,
   };
 };

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -19,7 +19,10 @@ const runDevServer = (webpackDevServer, compiler) => {
 
   const port = 8080;
   const projectPath = process.cwd();
-  const devServerOverrides = compiler.compilers[0].options ? compiler.compilers[0].options.devServer : null;
+
+  const devServerOverrides = compiler.compilers[0].options
+    ? compiler.compilers[0].options.devServer
+    : null;
 
   const localOpts = {
     port,

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -19,7 +19,7 @@ const runDevServer = (webpackDevServer, compiler) => {
 
   const port = 8080;
   const projectPath = process.cwd();
-  const devServerOverrides = compiler.options ? compiler.options.devServer : null;
+  const devServerOverrides = compiler.options ? compiler.compiler[0].options.devServer : null;
 
   const localOpts = {
     port,

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -9,7 +9,7 @@ const logger = require('./logger');
 const WebPackDevServer = require('webpack-dev-server');
 /**
  * Run the webpack-dev-server.
- * @param compiler
+ * @param compiler Instance of webpack MultiCompiler.
  * @param webpackDevServer
  * @returns {Server}
  */
@@ -19,7 +19,7 @@ const runDevServer = (webpackDevServer, compiler) => {
 
   const port = 8080;
   const projectPath = process.cwd();
-  const devServerOverrides = compiler.options ? compiler.compiler[0].options.devServer : null;
+  const devServerOverrides = compiler.compilers[0].options ? compiler.compilers[0].options.devServer : null;
 
   const localOpts = {
     port,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/febs",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "REI's next-gen front-end build system.",
   "main": "index.js",
   "directories": {

--- a/test/index-dev-spec.js
+++ b/test/index-dev-spec.js
@@ -476,7 +476,10 @@ describe('FEBS Development Tests', function () {
     });
 
     it('should create new server', function () {
-      const devServer = devServerFn(FakeWDS, () => {
+      const devServer = devServerFn(FakeWDS, {
+        compilers: [{
+          options: {},
+        }],
       });
       assert(devServer instanceof FakeWDS);
     });
@@ -490,7 +493,7 @@ describe('FEBS Development Tests', function () {
       const devServer = febs.startDevServerFn(FakeWDS)();
       assert(devServer instanceof FakeWDS);
 
-      // Assert webpack compiler passed to FakeWDS
+      // Assert webpack MultiCompiler passed to FakeWDS
       assert(devServer.compiler instanceof webpack.MultiCompiler);
     });
   });

--- a/test/index-dev-spec.js
+++ b/test/index-dev-spec.js
@@ -494,4 +494,23 @@ describe('FEBS Development Tests', function () {
       assert(devServer.compiler instanceof webpack.MultiCompiler);
     });
   });
+
+  describe('SSR Build', function () {
+    let febs;
+    before(function () {
+      febs = febsModule({}, {});
+    });
+
+    it('should be disabled on development builds', function () {
+      assert.ok(!febs.isSSR('development', {
+        ssr: true,
+      }));
+    });
+
+    it('should respect febs-config.ssr on prod build', function () {
+      assert.ok(!febs.isSSR('production', {
+        ssr: false,
+      }));
+    });
+  });
 });


### PR DESCRIPTION
- Disable the SSR build when running `febs dev`.
- Fix #104 

Some background:
The SSR build adds significant amount of build time consequently slowing down live-reloading considerably. This disables the SSR build by default when running `dev` build.